### PR TITLE
ci: quiet Dependabot (monthly + grouped + skip runtime-dep floor bumps)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,25 +1,45 @@
 version: 2
 updates:
-  # Keep GitHub Actions up to date.
+  # Keep GitHub Actions up to date — one grouped PR per month.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns: ["*"]
     commit-message:
       prefix: "ci"
 
-  # Keep Python dependencies up to date.
+  # Keep Python dependencies up to date — one grouped PR per month.
+  # Runtime dependencies use intentionally wide ">=" floors, so we do NOT want
+  # a PR every time one of them publishes a new release. Only dev/build tools
+  # (pytest, ruff, setuptools, ...) are updated here.
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    groups:
+      python:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "numpy"
+      - dependency-name: "pandas"
+      - dependency-name: "ortools"
+      - dependency-name: "joblib"
     commit-message:
       prefix: "deps"
 
-  # Keep the documentation's npm dependencies up to date.
+  # Keep the documentation's npm dependencies up to date — one grouped PR/month.
   - package-ecosystem: "npm"
     directory: "/docs"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    groups:
+      docs:
+        patterns: ["*"]
     commit-message:
       prefix: "docs"


### PR DESCRIPTION
## Why

The initial Dependabot config opened **one PR per dependency, weekly**, which produced a flood of PRs and email notifications. This tunes it down to a trickle without losing the useful updates.

## Changes to `.github/dependabot.yml`

- **Monthly instead of weekly** for all three ecosystems (actions, pip, npm).
- **Grouped updates** — each ecosystem now opens a **single** PR bundling all its updates, instead of one PR per dependency.
- **Skip runtime-dependency floor bumps** — `numpy`, `pandas`, `ortools` and `joblib` are ignored. They use intentionally wide `>=` floors, so there's no reason to raise the floor every time one publishes a release (which would also needlessly narrow the supported range for users). Dev/build tools (pytest, ruff, setuptools, …) and CI actions are still updated.

## Effect

At most **~3 grouped PRs per month** (one for actions, one for Python dev tools, one for the docs' npm deps), and **zero** runtime-dependency floor-bump PRs — down from ~9 individual PRs per week.

After this merges, the current individual Dependabot PRs can be closed; the next monthly run will reintroduce any still-relevant updates as grouped PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxwFUstgzLQGSDWwLExUv6)_