### PR TITLE
docs: refresh README features/API and expand CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,51 +1,169 @@
 # Contributing to pyworkforce
 
 Thanks for your interest in improving pyworkforce! Contributions of all kinds
-are welcome — bug reports, feature requests, documentation and code.
+are welcome — bug reports, feature requests, documentation and code. This guide
+walks through setting up a local environment and the checks we run.
 
-## Development setup
+## Table of contents
 
-pyworkforce targets Python 3.12–3.14.
+- [Reporting issues](#reporting-issues)
+- [Local development setup](#local-development-setup)
+- [Project layout](#project-layout)
+- [Running the tests](#running-the-tests)
+- [Linting and formatting](#linting-and-formatting)
+- [Working on the documentation](#working-on-the-documentation)
+- [Pull request workflow](#pull-request-workflow)
 
-```bash
-git clone https://github.com/rodrigo-arenas/pyworkforce.git
-cd pyworkforce
-python -m venv .venv && source .venv/bin/activate
-pip install -e ".[dev]"
+## Reporting issues
+
+- **Bugs:** open an issue with a minimal, reproducible example, the full
+  traceback, and your Python / pyworkforce versions.
+- **Features:** describe the use case and, ideally, the API you'd like to see.
+
+Use the issue templates under
+[`.github/ISSUE_TEMPLATE`](.github/ISSUE_TEMPLATE) where they apply.
+
+## Local development setup
+
+pyworkforce targets **Python 3.12–3.14**. You only need Python and git for the
+library; Node.js is needed only if you work on the docs.
+
+1. Fork the repository on GitHub, then clone your fork:
+
+   ```bash
+   git clone https://github.com/<your-username>/pyworkforce.git
+   cd pyworkforce
+   ```
+
+2. Create and activate a virtual environment:
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate        # Windows: .venv\Scripts\activate
+   ```
+
+3. Install pyworkforce in editable mode with the development extras. This pulls
+   in the runtime deps plus `pytest`, `pytest-cov`, `ruff` and `twine`:
+
+   ```bash
+   python -m pip install --upgrade pip
+   pip install -e ".[dev]"
+   ```
+
+4. Check that everything imports and the suite is green:
+
+   ```bash
+   python -c "import pyworkforce; print(pyworkforce.__version__)"
+   pytest pyworkforce/
+   ```
+
+> [!TIP]
+> All configuration (build metadata, dependencies, `ruff`, `pytest` and coverage
+> settings) lives in a single [`pyproject.toml`](pyproject.toml).
+
+## Project layout
+
+```
+pyworkforce/
+├── queuing/       # ErlangC, ErlangA, MultiErlangC, MultiErlangA
+├── scheduling/    # MinAbsDifference, MinRequiredResources
+├── rostering/     # MinHoursRoster
+├── shifts/        # shift-coverage builders
+├── utils/         # ParameterGrid, validation, results_to_dataframe
+├── base.py        # BaseWorkforce mixin (get_params / repr)
+└── */tests/       # tests live next to the code they cover
+docs/              # VitePress documentation site
+examples/          # runnable example scripts
 ```
 
-## Running the checks
+## Running the tests
 
-Please make sure the following pass before opening a pull request:
+We use [pytest](https://docs.pytest.org/) and
+[pytest-cov](https://pytest-cov.readthedocs.io/).
 
 ```bash
-# Tests + coverage (the CI gate requires >= 95%)
-pytest pyworkforce/ --cov=pyworkforce
+# Whole suite
+pytest pyworkforce/
 
-# Linting
+# A single module or test
+pytest pyworkforce/queuing/tests/test_abandonment.py
+pytest pyworkforce/queuing/tests/test_abandonment.py::test_erlanga_regression_metrics
+
+# With coverage (CI requires the total to stay at or above 95%)
+pytest pyworkforce/ --cov=pyworkforce --cov-report=term-missing --cov-fail-under=95
+
+# Docstring examples
+pytest --doctest-modules pyworkforce/
+```
+
+Guidelines:
+
+- **New features and bug fixes should come with tests.** Add them next to the
+  code, under the module's `tests/` folder.
+- Keep coverage at or above **95%**. Mark genuinely unreachable defensive
+  branches with `# pragma: no cover` rather than writing contrived tests.
+- **Validate numerical methods against an independent reference** where
+  practical. For example, `ErlangA` is checked against a Monte Carlo simulation
+  and against the Erlang C limit (as patience → ∞).
+
+## Linting and formatting
+
+We use [ruff](https://docs.astral.sh/ruff/) for both linting and formatting. The
+CI **lint gate runs `ruff check`**, and the test matrix only runs after it
+passes, so please run it locally first.
+
+```bash
+# Lint (this is what CI enforces)
 ruff check pyworkforce/
+
+# Auto-fix the issues ruff can fix safely (import order, f-strings, ...)
+ruff check --fix pyworkforce/
+
+# Format code you changed (ruff is also a formatter)
+ruff format pyworkforce/
 ```
 
-New features and bug fixes should come with tests. Numerical methods should be
-validated against an independent reference where practical (for example, the
-Erlang A model is checked against a Monte Carlo simulation and the Erlang C
-limit).
+A few conventions worth knowing (all configured in `pyproject.toml`):
 
-## Documentation
+- Line length is 120.
+- Tests may keep unused bindings (e.g. constructing inside `pytest.raises`).
+- `pyworkforce/utils/grid.py` is vendored from scikit-learn and is intentionally
+  left close to upstream.
 
-The docs are a [VitePress](https://vitepress.dev/) site under `docs/`:
+## Working on the documentation
+
+The docs are a [VitePress](https://vitepress.dev/) site under `docs/` and need
+Node.js (18+):
 
 ```bash
 cd docs
 npm install
-npm run docs:dev
+npm run docs:dev       # local dev server with hot reload
+npm run docs:build     # build the static site
 ```
 
-## Pull requests
+When you change documented behavior, please:
 
-- Branch off `main` and keep pull requests focused.
-- Describe the motivation and summarize the change.
-- Update the release notes (`docs/release-notes.md`) for user-facing changes.
+- update the relevant guide / API page under `docs/`;
+- keep tutorial code blocks runnable and show **real** outputs (run the snippet
+  and paste what it prints);
+- add an entry to the release notes (`docs/release-notes.md`).
+
+## Pull request workflow
+
+1. Create a feature branch off `main` and keep the PR focused on one change.
+2. Make sure the checks pass locally:
+
+   ```bash
+   ruff check pyworkforce/
+   pytest pyworkforce/ --cov=pyworkforce --cov-fail-under=95
+   ```
+
+3. Write a clear PR description: the motivation, a summary of the change, and any
+   trade-offs. Reference related issues.
+4. Update `docs/release-notes.md` for user-facing changes.
+5. CI (lint + the test matrix across Python 3.12–3.14 on Linux, macOS and
+   Windows) must be green before a PR is merged.
 
 ## Code of conduct
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,13 @@
 
 # pyworkforce
 Tools for workforce management problems such as queue staffing, shift scheduling,
-rostering, and operations research optimization.
+rostering, and operations research optimization. It is geared toward call /
+contact centers, but the same techniques apply to hospitals, retail, logistics,
+network capacity planning and any operation that has to match a variable demand
+with a finite number of resources.
 
-The full documentation is available at
-[rodrigo-arenas.github.io/pyworkforce](https://rodrigo-arenas.github.io/pyworkforce/).
+📖 **Full documentation and tutorials:**
+[rodrigo-arenas.github.io/pyworkforce](https://rodrigo-arenas.github.io/pyworkforce/)
 
 ## Installation
 
@@ -34,51 +37,45 @@ If the issue is related to OR-Tools, check the
 For runnable examples, see the
 [examples folder](https://github.com/rodrigo-arenas/pyworkforce/tree/main/examples).
 
-## What pyworkforce Does
+## Features
 
-pyworkforce is organized around three planning steps:
+pyworkforce is organized around three planning steps — *how many resources do I
+need?* → *how many per shift?* → *who works when?* — plus helpers that tie them
+together:
 
-### Queuing
+- **Queuing**
+  - `ErlangC` — the classic M/M/c queue (infinite patience).
+  - `ErlangA` — the M/M/c+M queue with customer **abandonment** (patience),
+    computed exactly from the birth–death stationary distribution.
+  - `MultiErlangC` / `MultiErlangA` — evaluate many scenarios from a parameter
+    grid in parallel, scikit-learn style.
+- **Shift coverage helpers** (`pyworkforce.shifts`) — build the `shifts_coverage`
+  arrays the schedulers expect from clock hours, spans or explicit periods,
+  instead of hand-writing 0/1 arrays.
+- **Scheduling** (`pyworkforce.scheduling`) — `MinAbsDifference` and
+  `MinRequiredResources` decide how many people to place on each shift, built on
+  [OR-Tools](https://developers.google.com/optimization).
+- **Rostering** (`pyworkforce.rostering`) — `MinHoursRoster` assigns named people
+  to days and shifts while respecting banned shifts, rest days, minimum hours,
+  non-sequential shifts and preferences.
+- **A scikit-learn-friendly API** — consistent constructors with clear validation
+  messages, `get_params()` and readable `repr()` on every estimator, the last
+  result stored as `solution_`, and `results_to_dataframe` to turn grid results
+  into tidy `pandas` DataFrames.
 
-Use `pyworkforce.queuing` when you need to estimate how many resources are required
-to handle incoming work, for example calls arriving at a call center. The current
-implementation uses Erlang C assumptions: constant arrival rate, infinite queue,
-and no customer dropout.
+A brief introduction to the queuing and scheduling ideas can be found in these
+posts:
+[workforce planning](https://towardsdatascience.com/workforce-planning-optimization-using-python-69af0ef9011a)
+and [scheduling](https://towardsdatascience.com/how-to-solve-scheduling-problems-in-python-36a9af8de451).
+
+## Queuing
+
+Estimate how many resources are required to handle incoming work, for example
+calls arriving at a call center.
 
 ![queue_system](https://raw.githubusercontent.com/rodrigo-arenas/pyworkforce/main/docs/images/erlangc_queue_system.png)
 
-- **queuing.ErlangC:** Calculate staffing requirements and performance metrics for one queue scenario.
-- **queuing.ErlangA:** Like Erlang C, but models customers who **abandon** the queue if they wait
-  too long (the M/M/c+M queue). Closer to reality for most contact centers.
-- **queuing.MultiErlangC:** Run multiple Erlang C scenarios from a parameter grid.
-
-### Shift coverage helpers
-
-Use `pyworkforce.shifts` to build the `shifts_coverage` arrays the schedulers expect
-from human-friendly descriptions (clock hours, spans or explicit period indices) instead
-of hand-writing 0/1 arrays.
-
-### Scheduling
-
-Use `pyworkforce.scheduling` when you already know the required resources by time
-interval and need to choose how many people to place on each predefined shift.
-
-- **scheduling.MinAbsDifference:** Minimizes the total absolute difference between required and scheduled resources.
-- **scheduling.MinRequiredResources:** Minimizes the total weighted number of scheduled resources while ensuring every interval is covered.
-
-### Rostering
-
-Use `pyworkforce.rostering` when you have named resources and need to assign them
-to days and shifts while respecting rules such as banned shifts, rest days,
-minimum working hours, and preferences.
-
-- **rostering.MinHoursRoster:** Builds a resource-level roster that covers shift requirements with the minimum scheduled hours.
-
-### Queue systems:
-
-A brief introduction can be found in this [medium post](https://towardsdatascience.com/workforce-planning-optimization-using-python-69af0ef9011a)
-
-#### Example:
+### Erlang C
 
 ```python
 from pyworkforce.queuing import ErlangC
@@ -90,17 +87,18 @@ print("positions_requirements: ", positions_requirements)
 ```
 Output:
 ```
->> positions_requirements:  {'raw_positions': 14, 
-                             'positions': 20, 
-                             'service_level': 0.8883500191794669, 
-                             'occupancy': 0.7142857142857143, 
+>> positions_requirements:  {'raw_positions': 14,
+                             'positions': 20,
+                             'service_level': 0.8883500191794669,
+                             'occupancy': 0.7142857142857143,
                              'waiting_probability': 0.1741319335950498}
 ```
 
-#### Modeling abandonment with Erlang A:
+### Erlang A (modeling abandonment)
 
-Real customers hang up if they wait too long. `ErlangA` adds a `patience` parameter and
-reports the abandonment probability, typically requiring fewer agents than Erlang C:
+Real customers hang up if they wait too long. `ErlangA` adds a `patience`
+parameter and reports the abandonment probability, typically requiring fewer
+agents than Erlang C:
 
 ```python
 from pyworkforce.queuing import ErlangA
@@ -121,51 +119,58 @@ Output:
                    'average_speed_of_answer': 0.125...}
 ```
 
-If you want to run several scenarios at the same time, use `MultiErlangC`.
-For example, this tries different service-level targets:
+### Many scenarios at once
+
+`MultiErlangC` / `MultiErlangA` evaluate a parameter grid in parallel, and
+`results_to_dataframe` turns the results into a tidy table:
 
 ```python
 from pyworkforce.queuing import MultiErlangC
+from pyworkforce.utils import results_to_dataframe
 
 param_grid = {"transactions": [100], "aht": [3], "interval": [30], "asa": [20 / 60], "shrinkage": [0.3]}
 multi_erlang = MultiErlangC(param_grid=param_grid, n_jobs=-1)
 
-required_positions_scenarios = {"service_level": [0.8, 0.85, 0.9], "max_occupancy": [0.8]}
+scenarios = {"service_level": [0.8, 0.85, 0.9], "max_occupancy": [0.8]}
+results = multi_erlang.required_positions(scenarios)
 
-positions_requirements = multi_erlang.required_positions(required_positions_scenarios)
-print("positions_requirements: ", positions_requirements)
+df = results_to_dataframe(results, multi_erlang.required_positions_params)
+print(df[["service_level", "positions", "service_level_result", "occupancy"]].round(4).to_string(index=False))
 ```
 Output:
 ```
->> positions_requirements:   [
-                                {
-                                    "raw_positions": 13,
-                                    "positions": 19,
-                                    "service_level": 0.7955947884177831,
-                                    "occupancy": 0.7692307692307693,
-                                    "waiting_probability": 0.285270453036493
-                                },
-                                {
-                                    "raw_positions": 14,
-                                    "positions": 20,
-                                    "service_level": 0.8883500191794669,
-                                    "occupancy": 0.7142857142857143,
-                                    "waiting_probability": 0.1741319335950498
-                                },
-                                {
-                                    "raw_positions": 15,
-                                    "positions": 22,
-                                    "service_level": 0.9414528428690223,
-                                    "occupancy": 0.6666666666666666,
-                                    "waiting_probability": 0.10204236700798798
-                                }
-                            ]
+ service_level  positions  service_level_result  occupancy
+          0.80         20                0.8884     0.7143
+          0.85         20                0.8884     0.7143
+          0.90         22                0.9415     0.6667
 ```
-### Scheduling
 
-A brief introduction can be found in this [medium post](https://towardsdatascience.com/how-to-solve-scheduling-problems-in-python-36a9af8de451)
+The input target stays under `service_level`; the achieved value is kept as
+`service_level_result`.
 
-#### Example:
+## Shift coverage helpers
+
+Describe shifts by their clock hours instead of writing 0/1 arrays. Overnight
+shifts wrap past midnight:
+
+```python
+from pyworkforce.shifts import shift_coverage_from_hours
+
+shifts_coverage = shift_coverage_from_hours({
+    "Morning":   (6, 14),
+    "Afternoon": (14, 22),
+    "Night":     (22, 6),
+}, num_periods=24)
+```
+
+The output plugs straight into the schedulers below. See also
+`shift_coverage_from_spans`, `shift_coverage_from_periods`,
+`validate_shift_coverage` and `coverage_to_dataframe`.
+
+## Scheduling
+
+Given the required resources per period, decide how many people to place on each
+predefined shift.
 
 ```python
 from pyworkforce.scheduling import MinAbsDifference, MinRequiredResources
@@ -182,53 +187,96 @@ shifts_coverage = {"Morning": [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0
                    "Night": [1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1],
                    "Mixed": [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0]}
 
-# Method One
+# Minimize the absolute difference between required and scheduled resources
 difference_scheduler = MinAbsDifference(num_days=2,
                                         periods=24,
                                         shifts_coverage=shifts_coverage,
                                         required_resources=required_resources,
                                         max_period_concurrency=27,
                                         max_shift_concurrency=25)
-
 difference_solution = difference_scheduler.solve()
 
-# Method Two
-
+# Minimize the (optionally weighted) number of scheduled resources while covering every period
 requirements_scheduler = MinRequiredResources(num_days=2,
                                               periods=24,
                                               shifts_coverage=shifts_coverage,
                                               required_resources=required_resources,
                                               max_period_concurrency=27,
                                               max_shift_concurrency=25)
-
 requirements_solution = requirements_scheduler.solve()
 
-print("difference_solution :", difference_solution)
-
-print("requirements_solution :", requirements_solution)
+print("difference_solution :", difference_solution["status"], difference_solution["cost"])
+print("requirements_solution :", requirements_solution["status"], requirements_solution["cost"])
 ```
 Output:
 ```
->> difference_solution: {'status': 'OPTIMAL', 
-                          'cost': 157.0, 
+>> difference_solution: {'status': 'OPTIMAL',
+                          'cost': 157.0,
                           'resources_shifts': [{'day': 0, 'shift': 'Morning', 'resources': 8},
                                                {'day': 0, 'shift': 'Afternoon', 'resources': 11},
-                                               {'day': 0, 'shift': 'Night', 'resources': 9}, 
-                                               {'day': 0, 'shift': 'Mixed', 'resources': 1}, 
-                                               {'day': 1, 'shift': 'Morning', 'resources': 13}, 
-                                               {'day': 1, 'shift': 'Afternoon', 'resources': 17}, 
-                                               {'day': 1, 'shift': 'Night', 'resources': 13}, 
-                                               {'day': 1, 'shift': 'Mixed', 'resources': 0}]
-                          }
+                                               {'day': 0, 'shift': 'Night', 'resources': 9},
+                                               {'day': 0, 'shift': 'Mixed', 'resources': 1},
+                                               ... ]}
 
->> requirements_solution: {'status': 'OPTIMAL', 
-                           'cost': 113.0, 
-                           'resources_shifts': [{'day': 0, 'shift': 'Morning', 'resources': 15}, 
-                                                {'day': 0, 'shift': 'Afternoon', 'resources': 13}, 
-                                                {'day': 0, 'shift': 'Night', 'resources': 19}, 
-                                                {'day': 0, 'shift': 'Mixed', 'resources': 3}, 
-                                                {'day': 1, 'shift': 'Morning', 'resources': 20}, 
-                                                {'day': 1, 'shift': 'Afternoon', 'resources': 20}, 
-                                                {'day': 1, 'shift': 'Night', 'resources': 23}, 
-                                                {'day': 1, 'shift': 'Mixed', 'resources': 0}]}
+>> requirements_solution: {'status': 'OPTIMAL',
+                           'cost': 113.0,
+                           'resources_shifts': [{'day': 0, 'shift': 'Morning', 'resources': 15},
+                                                {'day': 0, 'shift': 'Afternoon', 'resources': 13},
+                                                ... ]}
 ```
+
+`MinRequiredResources` also accepts a `cost_dict` to weight shifts differently
+(for example, more expensive night shifts).
+
+## Rostering
+
+Assign **named** people to days and shifts while respecting individual rules and
+preferences.
+
+```python
+from pyworkforce.rostering import MinHoursRoster
+
+roster = MinHoursRoster(
+    num_days=2,
+    resources=["ana@co", "ben@co", "cara@co", "dan@co", "eve@co"],
+    shifts=["Morning", "Night"],
+    shifts_hours=[8, 8],
+    min_working_hours=8,
+    max_resting=1,
+    required_resources={"Morning": [2, 2], "Night": [1, 1]},
+    banned_shifts=[{"resource": "ana@co", "shift": "Night", "day": 0}],
+    resources_preferences=[{"resource": "ana@co", "shift": "Morning"}],
+)
+
+solution = roster.solve()
+print(solution["status"], solution["resource_shifts"][:2])
+```
+Output:
+```
+OPTIMAL [{'resource': 'ana@co', 'day': 0, 'shift': 'Morning'},
+         {'resource': 'ana@co', 'day': 1, 'shift': 'Morning'}]
+```
+
+`ana@co` is given her preferred `Morning` shift and never `Night` on day 0,
+exactly as configured.
+
+## Documentation and tutorials
+
+The [documentation site](https://rodrigo-arenas.github.io/pyworkforce/) includes
+narrative guides, a full API reference, and self-contained, notebook-style
+tutorials with real outputs:
+
+- [End-to-end planning](https://rodrigo-arenas.github.io/pyworkforce/guide/end-to-end)
+  — demand → required positions → shift coverage → schedule → roster.
+- [Comparing scenarios](https://rodrigo-arenas.github.io/pyworkforce/guide/scenarios)
+  — grids and DataFrames.
+
+## Contributing
+
+Contributions are very welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for the
+local development setup, how to run the tests and linter, and the pull-request
+workflow.
+
+## License
+
+pyworkforce is released under the [MIT License](LICENSE).


### PR DESCRIPTION
## What

Brings the README up to date with everything added in the 0.53.0 line and turns `CONTRIBUTING.md` into a real local-development guide. Documentation only — no code changes.

### README
- New **Features** overview covering the full current API: `ErlangC`, `ErlangA`, `MultiErlangC` / `MultiErlangA`, the `pyworkforce.shifts` coverage builders, `results_to_dataframe`, and the scikit-learn-friendly conventions (`get_params()`, `repr()`, `solution_`, validation).
- Corrected the queuing intro (it no longer claims "no customer dropout" now that `ErlangA` models abandonment).
- Added new examples with **verified outputs**: shift-coverage builder, grid sweep rendered as a DataFrame, and a rostering example. Trimmed the long scheduling output for readability.
- Added a **Documentation & tutorials** section linking the site and the end-to-end / scenarios tutorials, plus **Contributing** and **License** sections.

### CONTRIBUTING
- Step-by-step **local setup** (venv + `pip install -e ".[dev]"`), a project-layout map, and an issue-reporting section.
- **Testing**: running the whole suite, a single test, coverage with the 95% gate, and doctests.
- **Linting & formatting** with ruff (`ruff check`, `--fix`, `ruff format`) and the conventions from `pyproject.toml`.
- **Docs** workflow (VitePress) and a **pull-request checklist**.

All README/CONTRIBUTING code snippets were run against the current package and show their real output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxwFUstgzLQGSDWwLExUv6)_