### PR TITLE
ci: versioned docs (stable/development), fix duplicate PR CI runs, conda-forge recipe

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,6 +1,9 @@
 name: Tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,63 +1,98 @@
 name: Deploy Docs
 
-# Build the VitePress site and deploy it to GitHub Pages.
+# Push to main → builds "development" docs.
+# Push of a v* tag → builds "stable" docs + updates the root redirect.
 on:
   push:
     branches: [main]
-    paths:
-      - 'docs/**'
-      - '.github/workflows/docs.yml'
+    tags:
+      - 'v*'
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Docs version to deploy'
+        required: true
+        default: development
+        type: choice
+        options:
+          - development
+          - stable
 
-# Allow only one concurrent deployment.
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write  # required by peaceiris/actions-gh-pages
 
 concurrency:
-  group: pages
+  group: docs-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: docs
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+
+      - name: Determine docs version
+        id: meta
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.ref_type }}" == "tag" ]]; then
+            echo "version=stable" >> $GITHUB_OUTPUT
+          else
+            echo "version=development" >> $GITHUB_OUTPUT
+          fi
+
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
           cache-dependency-path: docs/package-lock.json
-      - name: Setup Pages
-        uses: actions/configure-pages@v6
+
       - name: Install dependencies
+        working-directory: docs
         run: npm ci
+
       - name: Build with VitePress
+        working-directory: docs
         run: npm run docs:build
         env:
-          # Public Google Analytics measurement ID (not a credential), stored as
-          # a repository Variable. The secret fallback keeps it working if it is
-          # configured as a Secret instead.
+          DOCS_VERSION: ${{ steps.meta.outputs.version }}
           GA_MEASUREMENT_ID: ${{ vars.GA_MEASUREMENT_ID || secrets.GA_MEASUREMENT_ID }}
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
-        with:
-          path: docs/.vitepress/dist
 
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5
+      - name: Deploy versioned docs
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/.vitepress/dist
+          destination_dir: ${{ steps.meta.outputs.version }}
+          keep_files: true
+
+      - name: Create root redirect (stable deploys only)
+        if: steps.meta.outputs.version == 'stable'
+        run: |
+          mkdir -p /tmp/root-redirect
+          cat > /tmp/root-redirect/index.html << 'HTMLEOF'
+          <!DOCTYPE html>
+          <html lang="en">
+          <head>
+            <meta charset="utf-8">
+            <meta http-equiv="refresh" content="0; url=stable/">
+            <title>pyworkforce documentation</title>
+            <link rel="canonical" href="stable/">
+          </head>
+          <body>
+            <p>Redirecting to <a href="stable/">stable documentation</a>...</p>
+          </body>
+          </html>
+          HTMLEOF
+
+      - name: Deploy root redirect
+        if: steps.meta.outputs.version == 'stable'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: /tmp/root-redirect
+          keep_files: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,13 @@
 name: Publish to PyPI
 
-# Build and publish the package to PyPI when a GitHub Release is published.
+# Build and publish the package to PyPI when a v* tag is pushed.
 # Uses PyPI Trusted Publishing (OIDC) — no API token needs to be stored.
 # Configure the trusted publisher once at:
 #   https://pypi.org/manage/project/pyworkforce/settings/publishing/
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:
 
 permissions:

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -1,5 +1,9 @@
 import { defineConfig } from 'vitepress'
 
+// "stable" on tag releases, "development" on main-branch pushes.
+const docsVersion = process.env.DOCS_VERSION ?? 'development'
+const base = `/pyworkforce/${docsVersion}/`
+
 // Google Analytics measurement ID (e.g. "G-XXXXXXXXXX"), injected at build time.
 // This is a PUBLIC identifier (it ships in the page), not a credential.
 const gaId = process.env.GA_MEASUREMENT_ID
@@ -25,15 +29,15 @@ export default defineConfig({
     'Tools for workforce management: queue staffing (Erlang C / Erlang A), ' +
     'shift scheduling, rostering and operations-research optimization.',
 
-  // Deployed to https://rodrigo-arenas.github.io/pyworkforce/
-  base: '/pyworkforce/',
+  // base is /pyworkforce/stable/ or /pyworkforce/development/ depending on DOCS_VERSION.
+  base,
   lang: 'en-US',
   cleanUrls: true,
   lastUpdated: true,
   ignoreDeadLinks: true,
 
   head: [
-    ['link', { rel: 'icon', href: '/pyworkforce/favicon.ico' }],
+    ['link', { rel: 'icon', href: `${base}favicon.ico` }],
     ...analyticsHead,
   ],
 
@@ -42,9 +46,13 @@ export default defineConfig({
       { text: 'Guide', link: '/guide/introduction' },
       { text: 'API', link: '/api/queuing' },
       { text: 'Release Notes', link: '/release-notes' },
+      { text: 'PyPI', link: 'https://pypi.org/project/pyworkforce/' },
       {
-        text: 'PyPI',
-        link: 'https://pypi.org/project/pyworkforce/',
+        text: docsVersion,
+        items: [
+          { text: 'stable', link: 'https://rodrigo-arenas.github.io/pyworkforce/stable/' },
+          { text: 'development', link: 'https://rodrigo-arenas.github.io/pyworkforce/development/' },
+        ],
       },
     ],
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,58 @@
+{% set name = "pyworkforce" %}
+{% set version = "0.5.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: ae5c9dfcc24a334437e09af97b8a2955edb71711ca32b06e367381505860bd64
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  # Pure Python — no compiled extensions, runs on all platforms.
+  noarch: python
+
+requirements:
+  host:
+    - python >=3.12,<3.15
+    - pip
+    - setuptools >=82.0.1
+    - wheel
+  run:
+    - python >=3.12,<3.15
+    - numpy >=2.5.0
+    - pandas >=2.2.0
+    # NOTE: conda-forge ships ortools-python (currently 9.6); pypi requires >=9.15.
+    # Relax the lower bound here so conda users can install; tighten once
+    # the ortools-python feedstock is updated past 9.15.
+    - ortools-python >=9.6
+    - joblib >=1.4.2
+
+test:
+  imports:
+    - pyworkforce
+    - pyworkforce.queuing
+    - pyworkforce.scheduling
+    - pyworkforce.rostering
+    - pyworkforce.shifts
+  requires:
+    - pip
+  commands:
+    - pip check
+
+about:
+  home: https://github.com/rodrigo-arenas/pyworkforce
+  summary: >-
+    Tools for workforce management: queue staffing (Erlang C/A),
+    shift scheduling, rostering and operations-research optimization.
+  license: MIT
+  license_file: LICENSE
+  doc_url: https://rodrigo-arenas.github.io/pyworkforce/
+  dev_url: https://github.com/rodrigo-arenas/pyworkforce
+
+extra:
+  recipe-maintainers:
+    - rodrigo-arenas


### PR DESCRIPTION
## Summary

- **Versioned docs** (`docs.yml`): deploys to `/pyworkforce/stable/` on every `v*` tag push and `/pyworkforce/development/` on every merge to `main`, using `peaceiris/actions-gh-pages` with `keep_files: true` so the two versions are independent. A stable deploy also writes a root `index.html` redirect. A `workflow_dispatch` input lets you trigger either version manually.
- **PyPI publish on tag** (`publish.yml`): trigger changed from `release: published` to `push: tags: v*`. No changes needed to the PyPI trusted publisher config — it checks repo/workflow, not the trigger event.
- **VitePress config**: `base` path is now driven by the `DOCS_VERSION` env var (`/pyworkforce/stable/` or `/pyworkforce/development/`); favicon ref updated accordingly; version-picker dropdown added to the nav bar.
- **Fix duplicate CI runs** (`ci-tests.yml`): `on: [push, pull_request]` replaced with `push: branches: [main]` + `pull_request`, so pushing to a PR branch no longer fires two parallel CI runs (the root cause of rebase friction on PRs).
- **conda-forge recipe** (`recipe/meta.yaml`): ready-to-submit recipe for `conda-forge/staged-recipes`. After the one-time PR is merged there, the conda-forge bot auto-updates the feedstock on every PyPI release — no extra CI needed here.

## ortools version gap

`pyproject.toml` requires `ortools>=9.15.6755` (PyPI), but conda-forge's `ortools-python` feedstock is currently at **9.6**. The recipe relaxes the lower bound to `>=9.6` so conda users can install the package; the constraint should be tightened once the `ortools-python` feedstock is bumped past 9.15. Consider opening an issue on the [ortools-python feedstock](https://github.com/conda-forge/ortools-python-feedstock) to request a version bump, or verify that 9.6 is compatible enough for conda users in the meantime.

## Setup steps after merge

1. In repo **Settings → Pages**, change source from "GitHub Actions" to **Deploy from branch → gh-pages / (root)** — required by the switch to `peaceiris/actions-gh-pages`.
2. To publish on conda-forge: fork `conda-forge/staged-recipes`, copy `recipe/meta.yaml` into `recipes/pyworkforce/meta.yaml`, and open a PR.

## Test plan

- [ ] Merge to `main` → confirm `docs.yml` deploys to `development/` on the `gh-pages` branch
- [ ] After first run: configure Pages source as above
- [ ] Push a `v*` tag → confirm `docs.yml` deploys to `stable/` + root redirect, and `publish.yml` publishes to PyPI
- [ ] Open a PR and push a commit to it → confirm only one CI run fires (no duplicate `push` + `pull_request`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)