### PR TITLE
Improve docs, README, and contributor experience

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,8 @@ walks through setting up a local environment and the checks we run.
 - [Running the tests](#running-the-tests)
 - [Linting and formatting](#linting-and-formatting)
 - [Working on the documentation](#working-on-the-documentation)
+- [Adding models, examples and docs](#adding-models-examples-and-docs)
+- [Contributor roadmap](#contributor-roadmap)
 - [Pull request workflow](#pull-request-workflow)
 
 ## Reporting issues
@@ -155,6 +157,85 @@ When you change documented behavior, please:
 - keep tutorial code blocks runnable and show **real** outputs (run the snippet
   and paste what it prints);
 - add an entry to the release notes (`docs/release-notes.md`).
+
+## Adding models, examples and docs
+
+### Adding a new solver or model
+
+New optimization models should fit the existing project style:
+
+- Put the implementation in the closest domain package (`queuing`, `staffing`,
+  `scheduling`, `rostering`, `breaks`, or a new package only when the domain is
+  genuinely new).
+- Keep the public API explicit: constructor arguments should be named, validated
+  up front, and documented.
+- Return a plain dictionary from `solve()` / sizing methods, and store the last
+  result on `solution_` where that pattern applies.
+- Prefer clear `ValueError` messages for invalid user input rather than letting
+  OR-Tools, NumPy, or pandas fail later with low-level errors.
+- Add focused tests next to the module under `*/tests/`. Include infeasible or
+  invalid-input cases when they are part of the expected behavior.
+- Document the business problem, assumptions, inputs, output interpretation, and
+  common pitfalls before opening the PR.
+
+For numerical queueing models, validate against an independent reference where
+possible: published formulas, a small brute-force calculation, a simulation, or
+known limiting behavior.
+
+### Adding examples
+
+Examples under `examples/` should be runnable with:
+
+```bash
+python examples/path/to/example.py
+```
+
+Keep datasets small and inline unless the point of the example is file I/O.
+Use business-friendly names (`Billing`, `Technical`, `Morning`, `Night`) and
+print the key output a user should inspect. If an example needs a larger data
+file, include a short note explaining how to scale the pattern to real data.
+
+Good example themes:
+
+- contact center staffing with Erlang C, Erlang A, and Erlang B;
+- multi-skill staffing for language or support queues;
+- shift coverage from hourly demand;
+- named roster generation with banned shifts and preferences;
+- break scheduling while preserving minimum coverage;
+- end-to-end planning pipelines that join several modules.
+
+### Documentation guidelines
+
+Every major guide should answer the same practical questions:
+
+- **Problem statement:** what business decision does this model support?
+- **When to use it:** what assumptions make it appropriate?
+- **Input format:** shape, units, and key constraints.
+- **Code example:** copy-paste runnable and small enough to understand.
+- **Output explanation:** what each important field means.
+- **Common pitfalls:** units, infeasibility, assumptions, or modeling traps.
+
+Do not over-market. Make pyworkforce attractive by showing credible workflows,
+realistic inputs, and clear outputs.
+
+## Contributor roadmap
+
+These are useful issue ideas for new and experienced contributors:
+
+- More domain examples for healthcare staffing, retail operations, logistics,
+  support teams, service desks, and field operations.
+- Additional validation improvements for edge cases and clearer error messages.
+- Benchmark scenarios for larger scheduling, rostering, and break-scheduling
+  problems.
+- Visualization helpers for demand curves, scheduled coverage, roster matrices,
+  and break placement.
+- Additional workforce constraints such as weekly hour caps, skill-specific
+  rest rules, unavailable windows, fairness objectives, and weekend balancing.
+- Documentation translations and glossary improvements for workforce planning
+  terms.
+- Comparison notebooks that show how pyworkforce results relate to common
+  spreadsheet calculators and manual planning workflows.
+- More examples that export results to pandas DataFrames or downstream BI tools.
 
 ## Pull request workflow
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,41 @@
 [![Tests](https://github.com/rodrigo-arenas/pyworkforce/actions/workflows/ci-tests.yml/badge.svg?branch=main)](https://github.com/rodrigo-arenas/pyworkforce/actions/workflows/ci-tests.yml)
 [![Codecov](https://codecov.io/gh/rodrigo-arenas/pyworkforce/branch/main/graphs/badge.svg?branch=main&service=github)](https://codecov.io/github/rodrigo-arenas/pyworkforce?branch=main)
-[![PyPI Version](https://badge.fury.io/py/pyworkforce.svg)](https://badge.fury.io/py/pyworkforce)
+[![PyPI Version](https://badge.fury.io/py/pyworkforce.svg)](https://pypi.org/project/pyworkforce/)
 [![Python Version](https://img.shields.io/badge/python-3.12%20%7C%203.13%20%7C%203.14-blue)](https://www.python.org/downloads/)
 [![Docs](https://img.shields.io/badge/docs-pyworkforce.rodrigo--arenas.com-blue)](https://pyworkforce.rodrigo-arenas.com/stable/)
 
 # pyworkforce
 
-**Workforce management, made practical.** Covers the full planning pipeline from
-queue staffing to named rosters and break scheduling — built on Erlang queuing
-theory and OR-Tools constraint programming, with a scikit-learn-style API.
+**Practical workforce planning in Python: queue staffing, shift scheduling, rostering, and breaks.**
 
-> Geared toward contact / call centres, but the same techniques apply to
-> hospitals, retail, logistics and any operation matching variable demand to
-> finite resources.
+pyworkforce helps teams turn variable demand into staffing decisions with a friendly,
+scikit-learn-like API. It combines Erlang queueing models and OR-Tools
+constraint programming so workforce analysts, data scientists, operations
+researchers, and Python developers can move from forecast volumes to workable
+staffing plans without building every solver from scratch.
 
-📖 **Full documentation:** [pyworkforce.rodrigo-arenas.com](https://pyworkforce.rodrigo-arenas.com/stable/)
+It is useful for contact centers and call centers, but the same patterns apply
+to healthcare staffing, retail operations, logistics, support teams, service
+desks, and field operations.
 
----
+**Docs:** [pyworkforce.rodrigo-arenas.com](https://pyworkforce.rodrigo-arenas.com/stable/)  
+**Package:** [PyPI](https://pypi.org/project/pyworkforce/)  
+**Examples:** [examples/](examples/)
+
+## Why pyworkforce?
+
+- **More practical than spreadsheets:** reusable models, scenario sweeps, tested
+  calculations, and outputs that fit naturally into pandas workflows.
+- **Faster than custom scripts:** common workforce planning steps are packaged
+  behind consistent constructors, `solve()` methods, validation, and clear
+  result dictionaries.
+- **Lighter than enterprise WFM tools:** use it inside notebooks, pipelines,
+  internal apps, simulations, or decision-support workflows without adopting a
+  full platform.
+- **Built on proven methods:** Erlang C, Erlang A, and Erlang B for queue
+  staffing; OR-Tools CP-SAT for scheduling, rostering, and break placement.
+- **Designed for adoption:** small examples, copy-paste tutorials, and APIs that
+  feel familiar to Python users.
 
 ## Installation
 
@@ -24,332 +43,128 @@ theory and OR-Tools constraint programming, with a scikit-learn-style API.
 pip install pyworkforce
 ```
 
-Requires Python 3.12 – 3.14. conda-forge support is pending an update to the
-`ortools-python` feedstock for Python 3.12.
+pyworkforce supports Python 3.12, 3.13, and 3.14.
 
----
+## Planning pipeline
 
-## The planning workflow
+```text
+Forecast demand -> Queue staffing -> Multi-skill staffing -> Shift scheduling -> Rostering -> Break scheduling
+```
 
-pyworkforce covers five sequential planning steps:
+![Planning pipeline](https://raw.githubusercontent.com/rodrigo-arenas/pyworkforce/main/docs/images/planning_pipeline.svg)
 
-![Planning workflow](https://raw.githubusercontent.com/rodrigo-arenas/pyworkforce/main/docs/images/planning_pipeline.svg)
+| Step | Module | Typical question |
+| --- | --- | --- |
+| Queue staffing | `pyworkforce.queuing` | How many agents or channels do we need for a service target? |
+| Multi-skill staffing | `pyworkforce.staffing` | What skill-profile mix covers all queues at minimum cost? |
+| Shift scheduling | `pyworkforce.scheduling` | How many people should work each shift? |
+| Rostering | `pyworkforce.rostering` | Which named people work on which days and shifts? |
+| Break scheduling | `pyworkforce.breaks` | When can breaks happen without dropping below coverage? |
 
-| Step | Module | Key classes | Question answered |
-|------|--------|-------------|-------------------|
-| 1 | `pyworkforce.queuing` | `ErlangC`, `ErlangA`, `ErlangB` | How many agents / channels are needed? |
-| 2 | `pyworkforce.staffing` | `MultiSkillStaffing` | What is the optimal skill-profile mix? |
-| 3 | `pyworkforce.scheduling` | `MinRequiredResources`, `MinAbsDifference` | How many agents per shift? |
-| 4 | `pyworkforce.rostering` | `MinHoursRoster` | Who works on which day and shift? |
-| 5 | `pyworkforce.breaks` | `BreakScheduler` | When do individual breaks happen? |
+## What can I do in 5 minutes?
 
----
-
-## 1 — Queuing
-
-Estimate the number of agents (or channels) needed to meet a service target given
-an incoming demand.
-
-### Erlang C — infinite patience
-
-The classic M/M/c queue: Poisson arrivals, exponential handling times, unlimited
-waiting room.
-
-![Erlang C queue system](https://raw.githubusercontent.com/rodrigo-arenas/pyworkforce/main/docs/images/erlangc_queue_system.svg)
+### Size a contact-center queue with Erlang C
 
 ```python
 from pyworkforce.queuing import ErlangC
 
-erlang = ErlangC(transactions=100, aht=3, asa=20/60, interval=30, shrinkage=0.3)
+erlang = ErlangC(
+    transactions=100,  # calls in the interval
+    aht=3,             # average handle time, minutes
+    asa=20 / 60,       # answer-time target, minutes
+    interval=30,       # interval length, minutes
+    shrinkage=0.30,
+)
 
-result = erlang.required_positions(service_level=0.8, max_occupancy=0.85)
-print(result)
+print(erlang.required_positions(service_level=0.80, max_occupancy=0.85))
 ```
 
-```
+```text
 {'raw_positions': 14,
  'positions': 20,
- 'service_level': 0.8884,
- 'occupancy': 0.7143,
- 'waiting_probability': 0.1741}
+ 'service_level': 0.8883500191794669,
+ 'occupancy': 0.7142857142857143,
+ 'waiting_probability': 0.1741319335950498}
 ```
 
-### Erlang A — finite patience (abandonment)
+`raw_positions` is productive staffing. `positions` adds shrinkage for breaks,
+training, meetings, and other unavailable time.
 
-Adds a `patience` parameter: callers who wait too long hang up.
-Typically requires fewer agents than Erlang C.
-
-![Erlang A queue system — with abandonment](https://raw.githubusercontent.com/rodrigo-arenas/pyworkforce/main/docs/images/erlanga_queue_system.svg)
-
-```python
-from pyworkforce.queuing import ErlangA
-
-erlang = ErlangA(transactions=100, aht=3, asa=20/60, interval=30,
-                 patience=5, shrinkage=0.3)
-
-result = erlang.required_positions(service_level=0.8, max_occupancy=0.85,
-                                   max_abandonment=0.05)
-print(result)
-```
-
-```
-{'raw_positions': 13,
- 'positions': 19,
- 'service_level': 0.8584,
- 'occupancy': 0.7500,
- 'abandonment_probability': 0.0253,
- 'waiting_probability': 0.2265,
- 'average_speed_of_answer': 0.1258}
-```
-
-### Erlang B — pure loss (no waiting room)
-
-M/M/c/c queue: blocked calls are shed immediately.
-Use this for SIP trunk sizing, IVR channel capacity and overflow links.
-
-![Erlang B loss system](https://raw.githubusercontent.com/rodrigo-arenas/pyworkforce/main/docs/images/erlangb_loss_system.svg)
-
-```python
-from pyworkforce.queuing import ErlangB
-
-erlang = ErlangB(transactions=100, aht=3, interval=30, shrinkage=0.3)
-
-result = erlang.required_positions(max_blocking=0.02)
-print(result)
-```
-
-```
-{'raw_positions': 17,
- 'positions': 25,
- 'blocking_probability': 0.0183,
- 'occupancy': 0.9375}
-```
-
-### Running many scenarios at once
-
-`MultiErlangC`, `MultiErlangA` and `MultiErlangB` sweep a parameter grid in
-parallel (scikit-learn style) and `results_to_dataframe` turns the output into a
-tidy table:
+### Compare staffing scenarios
 
 ```python
 from pyworkforce.queuing import MultiErlangC
 from pyworkforce.utils import results_to_dataframe
 
-param_grid = {"transactions": [100], "aht": [3], "interval": [30],
-              "asa": [20/60], "shrinkage": [0.3]}
+param_grid = {
+    "transactions": [80, 100, 120],
+    "aht": [3],
+    "asa": [20 / 60],
+    "interval": [30],
+    "shrinkage": [0.20, 0.30],
+}
+
 multi = MultiErlangC(param_grid=param_grid, n_jobs=-1)
-
-results = multi.required_positions({"service_level": [0.80, 0.85, 0.90],
-                                    "max_occupancy": [0.85]})
-
+results = multi.required_positions({"service_level": [0.80], "max_occupancy": [0.85]})
 df = results_to_dataframe(results, multi.required_positions_params)
-print(df[["service_level", "positions", "occupancy"]].round(4).to_string(index=False))
+print(df[["transactions", "shrinkage", "positions", "service_level"]])
 ```
 
-```
- service_level  positions  occupancy
-          0.80         20     0.7143
-          0.85         20     0.7143
-          0.90         22     0.6667
-```
+Use this pattern to compare service levels, shrinkage assumptions, average
+handle time, patience, or arrival forecasts.
 
----
-
-## 2 — Multi-skill staffing
-
-When agents handle multiple contact types (e.g. English, Billing, Technical),
-`MultiSkillStaffing` finds the cheapest mix of skill profiles that meets every
-skill's coverage requirement. Flexible (multi-skilled) agents count towards all
-skills they hold.
-
-```python
-from pyworkforce.staffing import MultiSkillStaffing
-
-skills   = ["Billing", "Technical"]
-profiles = [
-    {"name": "Billing_only",   "skills": ["Billing"],              "cost": 1.0},
-    {"name": "Technical_only", "skills": ["Technical"],            "cost": 1.0},
-    {"name": "Flexible",       "skills": ["Billing", "Technical"], "cost": 1.5},
-]
-required = {"Billing": 5, "Technical": 3}
-
-ms = MultiSkillStaffing(skills=skills, profiles=profiles, required_positions=required)
-result = ms.solve()
-
-print(f"status={result['status']}  total={result['total_agents']}  cost={result['cost']}")
-for entry in result["agents_per_profile"]:
-    print(f"  {entry['profile']:18s}: {entry['agents']}")
-```
-
-```
-status=OPTIMAL  total=5  cost=6.5
-  Billing_only      : 2
-  Technical_only    : 0
-  Flexible          : 3
-```
-
-3 flexible + 2 billing-only = cost 6.5, vs 8.0 for pure dedicated agents.
-
----
-
-## 3 — Shift coverage helpers
-
-Build the `shifts_coverage` arrays the schedulers expect from clock hours instead
-of writing 0/1 arrays by hand:
+### Build shift coverage from clock hours
 
 ```python
 from pyworkforce.shifts import shift_coverage_from_hours
 
-shifts_coverage = shift_coverage_from_hours({
-    "Morning":   (6, 14),
-    "Afternoon": (14, 22),
-    "Night":     (22, 6),   # wraps past midnight
-}, num_periods=24)
-```
-
-See also `shift_coverage_from_spans`, `shift_coverage_from_periods`,
-`validate_shift_coverage` and `coverage_to_dataframe`.
-
----
-
-## 4 — Scheduling
-
-Given the required resources per period, decide how many agents to place on each
-shift using constraint programming (OR-Tools):
-
-```python
-from pyworkforce.scheduling import MinRequiredResources
-
-# One row per day; each value = required agents for that hour
-required_resources = [
-    [9, 11, 17, 9, 7, 12, 5, 11, 8, 9, 18, 17, 8, 12, 16, 8, 7, 12, 11, 10, 13, 19, 16, 7],
-    [13, 13, 12, 15, 18, 20, 13, 16, 17, 8, 13, 11, 6, 19, 11, 20, 19, 17, 10, 13, 14, 23, 16, 8],
-]
-shifts_coverage = {
-    "Morning":   [0,0,0,0,0,1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,0,0,0,0],
-    "Afternoon": [0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1,0,0,0],
-    "Night":     [1,1,1,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1],
-    "Mixed":     [0,0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1,0,0,0,0,0,0,0],
-}
-
-scheduler = MinRequiredResources(
-    num_days=2, periods=24,
-    shifts_coverage=shifts_coverage,
-    required_resources=required_resources,
-    max_period_concurrency=27, max_shift_concurrency=25,
+shifts_coverage = shift_coverage_from_hours(
+    {
+        "Morning": (6, 14),
+        "Afternoon": (14, 22),
+        "Night": (22, 6),  # wraps past midnight
+    },
+    num_periods=24,
 )
-solution = scheduler.solve()
-print(solution["status"], solution["cost"])
 ```
 
-```
-OPTIMAL 113.0
-```
+The result feeds the scheduling solvers directly, avoiding hand-written 0/1
+coverage arrays.
 
-`MinAbsDifference` minimises the absolute difference between required and
-scheduled; `MinRequiredResources` minimises total agents (optionally weighted by
-shift cost).
+## Main capabilities
 
----
+| Capability | Use it when | Start here |
+| --- | --- | --- |
+| Erlang C staffing | Callers wait and abandonment is ignored or negligible | [Erlang C guide](https://pyworkforce.rodrigo-arenas.com/stable/guide/erlangc) |
+| Erlang A staffing | Callers may abandon before being answered | [Erlang A guide](https://pyworkforce.rodrigo-arenas.com/stable/guide/erlanga) |
+| Erlang B channel sizing | Blocked calls are lost because there is no queue | [Erlang B guide](https://pyworkforce.rodrigo-arenas.com/stable/guide/erlangb) |
+| Multi-skill staffing | Agents can cover different skill combinations | [Staffing guide](https://pyworkforce.rodrigo-arenas.com/stable/guide/staffing) |
+| Shift scheduling | You need shift counts from hourly demand | [Scheduling guide](https://pyworkforce.rodrigo-arenas.com/stable/guide/scheduling) |
+| Employee rostering | You need named assignments with rules and preferences | [Rostering guide](https://pyworkforce.rodrigo-arenas.com/stable/guide/rostering) |
+| Break scheduling | You need meal/rest breaks while maintaining coverage | [Break guide](https://pyworkforce.rodrigo-arenas.com/stable/guide/breaks) |
 
-## 5 — Rostering
+## Project status
 
-Assign **named** people to days and shifts while respecting individual rules:
-
-```python
-from pyworkforce.rostering import MinHoursRoster
-
-roster = MinHoursRoster(
-    num_days=2,
-    resources=["ana@co", "ben@co", "cara@co", "dan@co", "eve@co"],
-    shifts=["Morning", "Night"],
-    shifts_hours=[8, 8],
-    min_working_hours=8,
-    max_resting=1,
-    required_resources={"Morning": [2, 2], "Night": [1, 1]},
-    banned_shifts=[{"resource": "ana@co", "shift": "Night", "day": 0}],
-    resources_preferences=[{"resource": "ana@co", "shift": "Morning"}],
-)
-
-solution = roster.solve()
-print(solution["status"])
-for a in solution["resource_shifts"][:3]:
-    print(a)
-```
-
-```
-OPTIMAL
-{'resource': 'ana@co', 'day': 0, 'shift': 'Morning'}
-{'resource': 'ana@co', 'day': 1, 'shift': 'Morning'}
-{'resource': 'ben@co', 'day': 0, 'shift': 'Night'}
-```
-
-`ana@co` is assigned her preferred shift and never `Night` on day 0, exactly
-as configured.
-
----
-
-## 6 — Break scheduling
-
-Assign break start times to agent slots within each shift, ensuring that
-simultaneous breaks never drop coverage below the required minimum:
-
-```python
-from pyworkforce.breaks import BreakScheduler
-
-shifts_coverage     = {"Morning": [1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,0],
-                       "Afternoon": [0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1]}
-scheduled_resources = {"Morning": [3], "Afternoon": [2]}
-breaks = [{"name": "Lunch", "duration_periods": 2,
-           "min_start_after": 2, "max_end_before": 2}]
-min_coverage = [[2,2,2,2,2,2,2,2,1,1,1,1,1,1,1,1]]
-
-scheduler = BreakScheduler(
-    num_days=1, periods=16,
-    shifts_coverage=shifts_coverage,
-    scheduled_resources=scheduled_resources,
-    breaks=breaks, min_coverage=min_coverage,
-)
-result = scheduler.solve()
-print(result["status"])
-for entry in result["break_schedule"]:
-    print(entry)
-```
-
-```
-OPTIMAL
-{'shift': 'Morning',   'day': 0, 'slot': 0, 'break_name': 'Lunch', 'start_period': 2, 'end_period': 4}
-{'shift': 'Morning',   'day': 0, 'slot': 1, 'break_name': 'Lunch', 'start_period': 4, 'end_period': 6}
-{'shift': 'Morning',   'day': 0, 'slot': 2, 'break_name': 'Lunch', 'start_period': 2, 'end_period': 4}
-{'shift': 'Afternoon', 'day': 0, 'slot': 0, 'break_name': 'Lunch', 'start_period': 10, 'end_period': 12}
-{'shift': 'Afternoon', 'day': 0, 'slot': 1, 'break_name': 'Lunch', 'start_period': 12, 'end_period': 14}
-```
-
----
+pyworkforce is beta-stage open source software. The core models are tested and
+usable for real planning experiments, but workforce policies vary by operation,
+country, and labor agreement. Validate assumptions, units, and constraints
+against your own environment before using results operationally.
 
 ## Documentation
 
-The [documentation site](https://pyworkforce.rodrigo-arenas.com/stable/)
-includes narrative guides, a full API reference, and self-contained tutorials
-with real outputs:
-
-- **[End-to-end tutorial](https://pyworkforce.rodrigo-arenas.com/stable/guide/end-to-end)**
-  — demand forecast → queuing → staffing mix → shift coverage → schedule → roster
-- **[Comparing scenarios](https://pyworkforce.rodrigo-arenas.com/stable/guide/scenarios)**
-  — grids, DataFrames, and service-level sweeps
-- **[API reference](https://pyworkforce.rodrigo-arenas.com/stable/api/queuing)**
-
-Background reading on the underlying techniques:
-[workforce planning](https://towardsdatascience.com/workforce-planning-optimization-using-python-69af0ef9011a)
-and [scheduling](https://towardsdatascience.com/how-to-solve-scheduling-problems-in-python-36a9af8de451).
-
----
+- [Get Started](https://pyworkforce.rodrigo-arenas.com/stable/guide/introduction)
+- [Quick Start](https://pyworkforce.rodrigo-arenas.com/stable/guide/quickstart)
+- [End-to-end planning tutorial](https://pyworkforce.rodrigo-arenas.com/stable/guide/end-to-end)
+- [Recipes](https://pyworkforce.rodrigo-arenas.com/stable/recipes/)
+- [API Reference](https://pyworkforce.rodrigo-arenas.com/stable/api/queuing)
+- [Release Notes](https://pyworkforce.rodrigo-arenas.com/stable/release-notes)
 
 ## Contributing
 
-Contributions are very welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for the
-local development setup, how to run the tests and linter, and the pull-request
-workflow.
+Contributions are welcome: examples, documentation, validation improvements,
+benchmarks, visualization helpers, additional workforce constraints, and bug
+reports all help. See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup,
+tests, docs, and roadmap ideas.
 
 ## License
 

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -44,7 +44,9 @@ export default defineConfig({
   themeConfig: {
     nav: [
       { text: 'Guide', link: '/guide/introduction' },
+      { text: 'Recipes', link: '/recipes/' },
       { text: 'API', link: '/api/queuing' },
+      { text: 'Contributing', link: '/contributing' },
       { text: 'Release Notes', link: '/release-notes' },
       { text: 'PyPI', link: 'https://pypi.org/project/pyworkforce/' },
       {
@@ -64,6 +66,7 @@ export default defineConfig({
             { text: 'Introduction', link: '/guide/introduction' },
             { text: 'Installation', link: '/guide/installation' },
             { text: 'Quick Start', link: '/guide/quickstart' },
+            { text: 'Contributing', link: '/contributing' },
           ],
         },
         {
@@ -71,6 +74,7 @@ export default defineConfig({
           items: [
             { text: 'End-to-end planning', link: '/guide/end-to-end' },
             { text: 'Comparing scenarios', link: '/guide/scenarios' },
+            { text: 'Recipes', link: '/recipes/' },
           ],
         },
         {
@@ -103,6 +107,14 @@ export default defineConfig({
             { text: 'Rostering', link: '/api/rostering' },
             { text: 'Shifts', link: '/api/shifts' },
             { text: 'Breaks', link: '/api/breaks' },
+          ],
+        },
+      ],
+      '/recipes/': [
+        {
+          text: 'Recipes',
+          items: [
+            { text: 'Overview', link: '/recipes/' },
           ],
         },
       ],

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,59 @@
+# Contributing
+
+Contributions are welcome across code, examples, documentation, tests, and
+planning scenarios. This page is the short docs-site version; the full workflow
+lives in [CONTRIBUTING.md](https://github.com/rodrigo-arenas/pyworkforce/blob/main/CONTRIBUTING.md).
+
+## Local setup
+
+```bash
+git clone https://github.com/<your-username>/pyworkforce.git
+cd pyworkforce
+python -m venv .venv
+source .venv/bin/activate        # Windows: .venv\Scripts\activate
+python -m pip install --upgrade pip
+pip install -e ".[dev]"
+```
+
+pyworkforce targets Python 3.12, 3.13, and 3.14.
+
+## Checks
+
+```bash
+ruff check pyworkforce/
+pytest pyworkforce/ --cov=pyworkforce --cov-fail-under=95
+```
+
+Documentation uses VitePress:
+
+```bash
+cd docs
+npm install
+npm run docs:dev
+npm run docs:build
+```
+
+## Good first contributions
+
+- Add runnable examples for healthcare, retail, logistics, service desks, or
+  field operations.
+- Improve validation messages and edge-case tests.
+- Add benchmark scenarios for larger scheduling and rostering cases.
+- Build small visualization helpers for coverage and schedules.
+- Document additional workforce constraints and how to model them.
+- Translate or localize selected docs pages.
+- Add comparison notebooks against spreadsheet-style calculations.
+
+## Documentation guidelines
+
+For each major module, aim to include:
+
+- the business problem being solved;
+- when to use the model and when not to use it;
+- input format and units;
+- a copy-paste runnable example;
+- expected output and how to interpret it;
+- common pitfalls.
+
+Keep examples small enough to read, but realistic enough that a workforce
+analyst can recognize the use case.

--- a/docs/guide/breaks.md
+++ b/docs/guide/breaks.md
@@ -152,3 +152,12 @@ A simple rule of thumb: pass the same `required_resources` array you used in
 the scheduling step. This ensures you never send so many agents on break that
 service levels drop below what was planned.
 :::
+
+## Common pitfalls
+
+- `BreakScheduler` assigns breaks to shift slots, not named employees.
+- `min_coverage` is the number of agents that must remain available, not the
+  number allowed to go on break.
+- Break windows are relative to the shift, not absolute clock periods.
+- If every slot must take a long break inside a narrow window, the problem may
+  be infeasible unless there is enough coverage slack.

--- a/docs/guide/erlanga.md
+++ b/docs/guide/erlanga.md
@@ -105,3 +105,12 @@ erlang.service_level(positions=14, asa=30 / 60)
 
 Use Erlang A when abandonment is material to your operation, and Erlang C as a
 conservative baseline.
+
+## Common pitfalls
+
+- `patience` is a mean patience time, not a hard maximum waiting time.
+- Keep `asa`, `aht`, `interval` and `patience` in the same unit.
+- Set a `max_abandonment` target when abandonment is a business constraint, not
+  just a modeling assumption.
+- Compare against Erlang C when you need a conservative upper-bound staffing
+  scenario.

--- a/docs/guide/erlangb.md
+++ b/docs/guide/erlangb.md
@@ -152,3 +152,13 @@ print(df[["transactions", "max_blocking", "raw_positions", "blocking_probability
 | Stable at any load? | Yes | No (`c > A` required) | Yes |
 | Key metric | blocking probability | service level | service level + abandonment |
 | Typical use | trunks, channels | call center headcount | call center headcount |
+
+## Common pitfalls
+
+- Erlang B is for blocked-calls-cleared systems. If callers can wait, use
+  Erlang C or Erlang A instead.
+- `aht` and `interval` must use the same unit.
+- `max_blocking` is usually a small probability such as `0.01` or `0.02`, not a
+  percentage integer.
+- Check occupancy as well as blocking when high utilization creates operational
+  risk.

--- a/docs/guide/erlangc.md
+++ b/docs/guide/erlangc.md
@@ -103,3 +103,13 @@ Erlang C assumes nobody ever hangs up, which makes it **conservative**: it
 tends to over-staff because, in reality, some customers abandon the queue. If
 abandonment matters for your operation, use the
 [Erlang A model](/guide/erlanga).
+
+## Common pitfalls
+
+- Keep `asa`, `aht` and `interval` in the same unit.
+- Do not treat `positions` and `raw_positions` as interchangeable:
+  `positions` includes shrinkage.
+- Erlang C requires enough productive positions for system stability. If demand
+  is too high for a proposed position count, increase positions or use
+  `required_positions`.
+- Use Erlang A when customer abandonment is a major part of the operation.

--- a/docs/guide/introduction.md
+++ b/docs/guide/introduction.md
@@ -7,7 +7,7 @@ call centers, but the same techniques apply to hospitals, retail, logistics,
 network capacity planning and any operation that has to match a variable
 demand with a finite number of resources.
 
-The package is organized around three planning steps that usually happen in
+The package is organized around planning steps that usually happen in
 sequence:
 
 ## 1. Queuing — *how many resources do I need?*

--- a/docs/guide/rostering.md
+++ b/docs/guide/rostering.md
@@ -83,3 +83,13 @@ works and who rests:
   assignments.
 - **`resources_prioritization`** — each entry `{"resource": ..., "weight": ...}`
   scales how strongly a resource's preferences are honored.
+
+## Common pitfalls
+
+- `required_resources` is per shift and per day, not per period.
+- `resources` must be unique. Use stable identifiers if names can repeat.
+- `max_resting` must be smaller than `num_days`.
+- Preferences are soft incentives; `banned_shifts` and
+  `non_sequential_shifts` are hard constraints.
+- If the model is infeasible, first reduce requirements or relax hard
+  constraints before tuning preference weights.

--- a/docs/guide/scheduling.md
+++ b/docs/guide/scheduling.md
@@ -110,3 +110,15 @@ scheduler = MinRequiredResources(
 
 Both solvers accept `max_search_time` (seconds, default `120`/`240`) and
 `num_search_workers` (default `2`) to bound the optimization.
+
+## Common pitfalls
+
+- `required_resources` must have one row per day and exactly `periods` values
+  per row.
+- `max_period_concurrency` and `max_shift_concurrency` are upper bounds. If
+  they are too low, the solver may correctly return `INFEASIBLE`.
+- Use `MinRequiredResources` when every period must be covered; use
+  `MinAbsDifference` when matching demand closely is more important than strict
+  coverage.
+- Shift definitions drive feasibility. Validate `shifts_coverage` before
+  assuming the demand pattern is impossible.

--- a/docs/guide/staffing.md
+++ b/docs/guide/staffing.md
@@ -169,3 +169,15 @@ integer programmes and typically solve in under a second at contact-centre scale
 - [Scheduling guide](/guide/scheduling) — placing the staffed mix across shifts
 - [End-to-end tutorial](/guide/end-to-end) — full planning pipeline
 - [API — Staffing](/api/staffing)
+
+## Common pitfalls
+
+- Every required skill must appear in at least one profile.
+- Costs are relative weights, not necessarily salaries. Keep them consistent
+  across profiles.
+- `required_positions` should usually use productive requirements
+  (`raw_positions`) when the staffing mix is later scheduled with shrinkage or
+  availability assumptions elsewhere.
+- Multi-skilled agents count toward every skill they hold; if that is not how
+  routing works in your operation, model narrower profiles or add downstream
+  constraints.

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,10 +3,10 @@ layout: home
 
 hero:
   name: pyworkforce
-  text: Workforce management, made practical
+  text: Practical workforce optimization in Python
   tagline: >-
-    Queue staffing, shift scheduling and rostering for call centers and any
-    operation that needs the right people at the right time.
+    Queue staffing, multi-skill staffing, shift scheduling, rostering and break
+    scheduling for operations that need the right people at the right time.
   actions:
     - theme: brand
       text: Get Started
@@ -14,6 +14,9 @@ hero:
     - theme: alt
       text: Quick Start
       link: /guide/quickstart
+    - theme: alt
+      text: Recipes
+      link: /recipes/
     - theme: alt
       text: View on GitHub
       link: https://github.com/rodrigo-arenas/pyworkforce
@@ -43,3 +46,26 @@ features:
       0/1 arrays.
     link: /guide/shifts
 ---
+
+## Planning pipeline
+
+```text
+Forecast demand -> Queue staffing -> Multi-skill staffing -> Shift scheduling -> Rostering -> Break scheduling
+```
+
+pyworkforce is useful beyond contact centers: healthcare staffing, retail
+operations, logistics, support teams, service desks and field operations all
+share the same planning problem of matching variable demand to finite resources.
+
+## Where should I start?
+
+| Goal | Page |
+| --- | --- |
+| Install and run the first example | [Quick Start](/guide/quickstart) |
+| Understand the full workflow | [End-to-end planning tutorial](/guide/end-to-end) |
+| Size call-center agents for 80/20 | [Erlang C](/guide/erlangc) |
+| Model abandonment | [Erlang A](/guide/erlanga) |
+| Size SIP trunks or channels | [Erlang B](/guide/erlangb) |
+| Solve short practical tasks | [Recipes](/recipes/) |
+| Check constructor and output details | [API Reference](/api/queuing) |
+| Contribute examples, docs or solvers | [Contributing](/contributing) |

--- a/docs/recipes/index.md
+++ b/docs/recipes/index.md
@@ -1,0 +1,177 @@
+# Recipes
+
+Recipes are short, task-oriented snippets for common workforce planning jobs.
+Use tutorials when you want a complete workflow; use recipes when you need one
+practical move to copy into a notebook or pipeline.
+
+## Queue staffing
+
+### How many agents do I need for 80/20 service level?
+
+Use Erlang C when callers wait and you are not modeling abandonment.
+
+```python
+from pyworkforce.queuing import ErlangC
+
+erlang = ErlangC(transactions=100, aht=3, asa=20 / 60, interval=30, shrinkage=0.3)
+result = erlang.required_positions(service_level=0.80, max_occupancy=0.85)
+
+print(result["positions"])
+```
+
+```text
+20
+```
+
+`positions` includes shrinkage. Use `raw_positions` when you need productive
+seats before shrinkage.
+
+### Compare service levels across shrinkage assumptions
+
+Use a `Multi*` estimator when you want a scenario table.
+
+```python
+from pyworkforce.queuing import MultiErlangC
+from pyworkforce.utils import results_to_dataframe
+
+param_grid = {
+    "transactions": [100],
+    "aht": [3],
+    "asa": [20 / 60],
+    "interval": [30],
+    "shrinkage": [0.20, 0.30, 0.40],
+}
+
+multi = MultiErlangC(param_grid=param_grid, n_jobs=-1)
+results = multi.required_positions({"service_level": [0.80], "max_occupancy": [0.85]})
+df = results_to_dataframe(results, multi.required_positions_params)
+
+print(df[["shrinkage", "raw_positions", "positions", "occupancy"]].to_string(index=False))
+```
+
+### Size SIP trunks with Erlang B
+
+Use Erlang B for pure-loss systems where blocked calls are cleared, not queued.
+
+```python
+from pyworkforce.queuing import ErlangB
+
+trunks = ErlangB(transactions=100, aht=3, interval=30)
+print(trunks.required_positions(max_blocking=0.02)["raw_positions"])
+```
+
+```text
+17
+```
+
+## Shift coverage and scheduling
+
+### Convert shift start/end hours into coverage arrays
+
+```python
+from pyworkforce.shifts import coverage_to_dataframe, shift_coverage_from_hours
+
+coverage = shift_coverage_from_hours(
+    {"Early": (6, 14), "Late": (14, 22), "Night": (22, 6)},
+    num_periods=24,
+)
+
+print(coverage_to_dataframe(coverage).loc[["Early", "Night"], [0, 6, 13, 22]].to_string())
+```
+
+### Export scheduled shift counts to a pandas DataFrame
+
+The solver returns a list of dictionaries, so pandas can consume it directly.
+
+```python
+import pandas as pd
+
+from pyworkforce.scheduling import MinRequiredResources
+from pyworkforce.shifts import shift_coverage_from_hours
+
+coverage = shift_coverage_from_hours({"Day": (8, 16), "Evening": (16, 24)}, num_periods=24)
+required = [[0, 0, 0, 0, 0, 0, 0, 0, 4, 4, 5, 5, 5, 5, 4, 4, 3, 3, 3, 3, 2, 2, 2, 2]]
+
+solver = MinRequiredResources(
+    num_days=1,
+    periods=24,
+    shifts_coverage=coverage,
+    required_resources=required,
+    max_period_concurrency=10,
+    max_shift_concurrency=10,
+)
+
+solution = solver.solve()
+df = pd.DataFrame(solution["resources_shifts"])
+print(df.to_string(index=False))
+```
+
+## Rostering
+
+### Avoid assigning a person to a banned shift
+
+Use `banned_shifts` for hard exclusions such as availability, certification, or
+labor-rule constraints.
+
+```python
+from pyworkforce.rostering import MinHoursRoster
+
+roster = MinHoursRoster(
+    num_days=2,
+    resources=["ana", "ben", "cara"],
+    shifts=["Morning", "Night"],
+    shifts_hours=[8, 8],
+    min_working_hours=8,
+    max_resting=1,
+    required_resources={"Morning": [1, 1], "Night": [1, 1]},
+    banned_shifts=[{"resource": "ana", "shift": "Night", "day": 0}],
+)
+
+solution = roster.solve()
+print(any(x == {"resource": "ana", "day": 0, "shift": "Night"} for x in solution["resource_shifts"]))
+```
+
+```text
+False
+```
+
+## Break scheduling
+
+### Schedule lunch breaks without dropping below coverage
+
+Set `min_coverage` to the minimum number of agents that must remain available
+in each period.
+
+```python
+from pyworkforce.breaks import BreakScheduler
+
+scheduler = BreakScheduler(
+    num_days=1,
+    periods=8,
+    shifts_coverage={"Day": [1, 1, 1, 1, 1, 1, 1, 1]},
+    scheduled_resources={"Day": [3]},
+    breaks=[{"name": "Lunch", "duration_periods": 2, "min_start_after": 1, "max_end_before": 1}],
+    min_coverage=[[2, 2, 2, 2, 2, 2, 2, 2]],
+)
+
+result = scheduler.solve()
+print(result["status"])
+print(result["break_schedule"][0])
+```
+
+```text
+OPTIMAL
+{'shift': 'Day', 'day': 0, 'slot': 0, 'break_name': 'Lunch', 'start_period': 3, 'end_period': 5}
+```
+
+## Common pitfalls
+
+- Keep time units consistent. If `aht` is in minutes, `asa`, `interval`, and
+  `patience` should be in minutes too.
+- Use Erlang A, not Erlang C, when abandonment materially affects staffing.
+- Give scheduling solvers realistic upper bounds in `max_period_concurrency`
+  and `max_shift_concurrency`; bounds that are too low make feasible plans look
+  infeasible.
+- Validate labor-policy assumptions before operational use. pyworkforce solves
+  the model you give it; it does not know your contracts, regulations, or local
+  operating rules unless you encode them.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,10 +2,19 @@
 
 ## 0.5.4
 
+### Documentation and project polish
+
+- Clearer README positioning for practical workforce planning across contact
+  centers, healthcare, retail, logistics, support teams and service operations.
+- Improved documentation navigation so users can move quickly from getting
+  started to queue staffing, multi-skill staffing, scheduling, rostering, break
+  scheduling, recipes and API details.
+- Added contributor guidance and roadmap ideas to make first issues and pull
+  requests easier to start.
+
 ### Maintenance
 
 - CI pipeline and deployment workflow improvements.
-- README and documentation updates.
 
 ## 0.5.3
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pyworkforce"
 dynamic = ["version"]
-description = "Common tools for workforce management, queuing, scheduling, rostering and optimization problems"
+description = "Practical workforce planning tools for queue staffing, shift scheduling, rostering, breaks, and operations research in Python"
 readme = "README.md"
 requires-python = ">=3.12,<3.15"
 license = "MIT"
@@ -15,11 +15,21 @@ authors = [
 ]
 keywords = [
     "workforce management",
+    "workforce planning",
     "call center",
+    "contact center",
+    "call center staffing",
+    "contact center staffing",
     "erlang",
+    "erlang c",
+    "erlang a",
+    "erlang b",
     "scheduling",
+    "shift scheduling",
     "rostering",
+    "employee rostering",
     "operations research",
+    "or-tools",
     "optimization",
 ]
 classifiers = [
@@ -27,6 +37,8 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Intended Audience :: Developers",
     "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Mathematics",
+    "Topic :: Office/Business :: Scheduling",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyworkforce" %}
-{% set version = "0.5.3" %}
+{% set version = "0.5.4" %}
 {% set python_min = "3.12" %}
 
 package:
@@ -26,7 +26,7 @@ requirements:
     - python >={{ python_min }}
     - numpy >=1.23
     - pandas >=2.2.0
-    - ortools-python >=9.0
+    - ortools-python >=9.6
     - joblib >=1.4.2
 
 test:


### PR DESCRIPTION
## Summary

- Rework README into a concise practical workforce planning landing page with pipeline, use cases, examples, status, and docs links.
- Improve docs landing/navigation, add recipes and contributor docs, and add common pitfalls to major guides.
- Expand contributor guidance and roadmap, update package metadata, release notes, and conda recipe metadata.

## Verification

- `conda run -n pyworkforce python -m pytest pyworkforce` -> 198 passed
- `conda run -n pyworkforce python -m ruff check --no-cache pyworkforce` -> passed
- `node "C:\Program Files\nodejs\node_modules\npm\bin\npm-cli.js" run docs:build` -> passed

## Follow-up

- Open a follow-up issue to add visualization helpers for demand, coverage, schedules, rosters, and breaks.
